### PR TITLE
Error handling: undefined/empty collection

### DIFF
--- a/trait/GameScene.hx
+++ b/trait/GameScene.hx
@@ -274,6 +274,9 @@ class GameScene extends Trait {
 
 		// TODO: check all collections
 		var coll = colls[0];
+		
+		// No collection assigned
+		if (coll == null) return null;
 
 		// Find collection data
 		var collData:TGameCollection = null;


### PR DESCRIPTION
Solves the following error:
```
> Uncaught TypeError: Cannot read property 'split' of undefined                 |        kha.js: 305
```